### PR TITLE
fix: unique resource names for databases and bump version to 0.0.7

### DIFF
--- a/dlt_source_notion/__init__.py
+++ b/dlt_source_notion/__init__.py
@@ -292,10 +292,12 @@ class DatabaseResource(DatabaseResourceBase):
             self.column_name_projection = column_name_projection
 
     def get_resource(self):
-        return database_resource(
+        res = database_resource(
             database_id=self.database_id,
             column_name_projection=self.column_name_projection,
         )
+        res.name = "database_" + short_hash(self.database_id)
+        return res
 
     def __str__(self):
         return f"DatabaseResource(database_id={self.database_id})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dlt-source-notion"
-version = "0.0.6"
+version = "0.0.7"
 description = "A DLT source for notion"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [


### PR DESCRIPTION
### Problem
When loading multiple Notion databases in a single pipeline, `dlt` failed with a "duplicate resource name" error. This happened because `DatabaseResource.get_resource()` was creating resources with a generic default name, causing collisions.

### Solution
- Updated `DatabaseResource.get_resource` to explicitly assign a unique name to the returned resource.
- The name is now generated as `database_<short_hash_of_db_id>`, ensuring uniqueness while remaining deterministic.

### Changes
- Modified `dlt_source_notion/__init__.py` to set `res.name` using the database ID hash.